### PR TITLE
force disable in latest HA

### DIFF
--- a/custom_components/cloud/__init__.py
+++ b/custom_components/cloud/__init__.py
@@ -1,7 +1,17 @@
 """Cloud."""
+from __future__ import annotations
+
 DOMAIN = "cloud"
 
-def setup(hass, config):
-    
-    # Return boolean to indicate that initialization was successful.
-    return True
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import bind_hass
+
+@bind_hass
+@callback
+def async_remote_ui_url(hass: HomeAssistant) -> str:
+    return ""
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    return False


### PR DESCRIPTION
add to configuration.yaml

```
logger:
  default: info
  filters:
    homeassistant.setup:
      - "[Cc]loud"
```

error in notifications is still present

i don't know if in previous version everything was clean, finding a better solution is probably a waste of time, after all this is HA devs fault